### PR TITLE
Fix virtual keyboard release event

### DIFF
--- a/Software/tools/virtual-keyboard/static/sketch.js
+++ b/Software/tools/virtual-keyboard/static/sketch.js
@@ -1,6 +1,6 @@
 // constants
 const SCALER_WIDTH = 100;
-
+const IPADDR = "10.4.27.28"
 // default sizes & keyboard measurements
 let w = 734, h = 667;
 let aspectratio = w/h;
@@ -220,7 +220,7 @@ function log_now(msg) {
     logs.push(log_str);
 
     // Send new message to server
-    fetch("http://192.168.178.103:8080", {
+    fetch("http://" + IPADDR + ":8080", {
         method: "POST",
         body: log_str,
         headers: {

--- a/Software/tools/virtual-keyboard/static/sketch.js
+++ b/Software/tools/virtual-keyboard/static/sketch.js
@@ -46,7 +46,7 @@ let send_to_server = true;
 // Initialisation
 function setup() {
     createCanvas(windowWidth, windowHeight);
-
+    
     // set colors per finger
     finger_coloring = [
         color("#cdb4db"),
@@ -134,7 +134,7 @@ function touchStarted(event) {
         saveToFile();
         return false;
     }
-
+    
     // check if any key is touched and log press
     kb_positions.forEach((finger, fi) => {
         finger.forEach((pos, pi) => {
@@ -149,8 +149,6 @@ function touchStarted(event) {
             if (w*x <= tx && tx <= w*xw &&
                 h*y <= ty - bottom_aligned*(windowHeight-h) &&
                 ty - bottom_aligned*(windowHeight-h) <= h*yh){
-                // logs.push(Date.now().toString() + " +" +
-                //           fi.toString() + pi.toString());
                 log_now("+ " + fi.toString() + pi.toString());
                 // re-generate suggested_key if the last one was pressed
                 if (suggested_key[0] == fi && suggested_key[1] == pi)
@@ -193,7 +191,7 @@ function touchEnded(event) {
         flip();
         return false;
     }
-
+    
     // check if any key is touched and log press    
     kb_positions.forEach((finger, fi) => {
         finger.forEach((pos, pi) => {
@@ -205,8 +203,6 @@ function touchEnded(event) {
             if (w*x <= tx && tx <= w*xw &&
                 h*y <= ty - bottom_aligned*(windowHeight-h) &&
                 ty - bottom_aligned*(windowHeight-h) <= h*yh){
-                // logs.push(Date.now().toString() + " -" +
-                //           fi.toString() + pi.toString());
                 log_now("- " + fi.toString() + pi.toString());
             }
         })

--- a/Software/tools/virtual-keyboard/static/sketch.js
+++ b/Software/tools/virtual-keyboard/static/sketch.js
@@ -36,6 +36,7 @@ let flipButton = [0,50/h,100/w,50/h];
 // global variables
 let logs = []; // the actual log
 let suggested_key = [0,0];
+let touchPositions = new Map();
 
 // flags
 let mirror = false; // mirror the shown keyboard?
@@ -91,13 +92,15 @@ function draw() {
                 strokeWeight(4);
                 stroke(255,0,0);
             }
-            touches.forEach(touch => { // consider all touches
-                if (w*x <= touch.x && touch.x <= w*xw &&
-                    h*y <= touch.y - bottom_aligned*(windowHeight-h) &&
-                    touch.y - bottom_aligned*(windowHeight-h) <= h*yh){
+
+            for (const [id, touch] of touchPositions) {
+                let [tx, ty] = touch;
+                if (w*x <= tx && tx <= w*xw &&
+                    h*y <= ty - bottom_aligned*(windowHeight-h) &&
+                    ty - bottom_aligned*(windowHeight-h) <= h*yh){
                     fill(0,255,0);
                 }
-            });
+            }
 
             // draw rect
             rect(w*x, bottom_aligned*(windowHeight-h)+h*y, w*key_size[0], h*key_size[1]);
@@ -124,7 +127,8 @@ function draw() {
 function touchStarted(event) {
     let tx = event.changedTouches[0].clientX;
     let ty = event.changedTouches[0].clientY;
-
+    touchPositions.set(event.changedTouches[0].identifier, [tx, ty]);
+    
     // check for save button press
     let [sx,sy,sw,sh] = saveButton;
     if (mirror)
@@ -179,8 +183,8 @@ function mouseDragged() {
 
 // process finalised touch events
 function touchEnded(event) {
-    let tx = event.changedTouches[0].clientX;
-    let ty = event.changedTouches[0].clientY;
+    let [tx, ty] = touchPositions.get(event.changedTouches[0].identifier)
+    touchPositions.delete(event.changedTouches[0].identifier);
 
     // check for flip button press
     let [sx,sy,sw,sh] = flipButton;


### PR DESCRIPTION
This fixes most release events. The only release events that are still not properly tracked are when one leaves the app while a touch is active, which is something we probably don't need to worry about.

To fix the issue, the change keeps track of all current touches, mapping every internal touch identifier to the touch's starting position. The starting position is then used as a reference when releasing a touch, ensuring that every touch ends at the same key it started, at least in the log. The internal identifier is provided by the p5.js API, which assigns every touch an identifier that is unique while the touch is still active.