### PR TITLE
Removed remaining timing breakpoints from output

### DIFF
--- a/Hardware/Firmware/mainboard/src/sensors.cpp
+++ b/Hardware/Firmware/mainboard/src/sensors.cpp
@@ -146,16 +146,14 @@ void readFifoBuffer(MPU6050 mpu) {
     // Clear the buffer so as we can get fresh values
     // The sensor is running a lot faster than our sample period
 
-    Serial.printf("after reset: %d \n", micros() - prev_micros);
-    prev_micros = micros();
+    __TIMING("after reset: %d \n");
 
     uxBits = xEventGroupGetBits(FifoResetEventGroup);
     while((uxBits & BIT_0) != 0){
         uxBits = xEventGroupGetBits(FifoResetEventGroup);
     }
 
-    Serial.printf("Before get: %d \n", micros() - prev_micros);
-    prev_micros = micros();
+    __TIMING("Before get: %d \n");
 
     // get current FIFO count
     fifoCount = mpu.getFIFOCount();


### PR DESCRIPTION
Transferred the last two remaining breakpoints to also use `__TIMING`, which is disabled by default.