### PR TITLE
Add support for 16MB flash size and other minor changes

### DIFF
--- a/Hardware/Firmware/mainboard/platformio.ini
+++ b/Hardware/Firmware/mainboard/platformio.ini
@@ -14,6 +14,7 @@ extra_configs = wifi.ini
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
+board_build.partitions = min_spiffs.csv
 framework = arduino
 lib_deps = ropg/ezTime
     jrowberg/I2Cdevlib-MPU6050

--- a/Hardware/Firmware/mainboard/platformio.ini
+++ b/Hardware/Firmware/mainboard/platformio.ini
@@ -14,7 +14,9 @@ extra_configs = wifi.ini
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
-board_build.partitions = min_spiffs.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
 framework = arduino
 lib_deps = ropg/ezTime
     jrowberg/I2Cdevlib-MPU6050

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -48,13 +48,17 @@ void setup(){
 
     Serial.println("Initialising i2c");
     setup_i2c(SDA, SCL);
-
+    
     // ------SETUP SENSORS-------
     Serial.println("Setting up Sensors");
     char unit_buffer[30];
     for (int i=0;i<SENSOR_COUNT;i++) {
         if (setup_sensor(i)) {
             Serial.println("--------WARNING: A SENSOR FAILED-------");
+            digitalWrite(LED_GREEN, HIGH);
+            // while (1){
+            //
+            // }
         }
         sprintf(unit_buffer, ":g%dx;g%dy;g%dz;a%dy;a%dp;a%dr", i,i,i,i,i,i);
         strcat(headerline, unit_buffer);
@@ -71,10 +75,10 @@ void setup(){
     write_values(headerline);
     digitalWrite(LED_BLUE, LOW);
     digitalWrite(LED_GREEN, HIGH);
-
+    
     // ------Parallelization setup------
     xTaskCreatePinnedToCore(task_fifo_reset, "fifo_resets", 10000, NULL, 1, &TaskFifoReset, 0);
-
+    
     timer_battery_check.start();
   
     // ---- TIME SINGLE CYCLE ----

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -42,10 +42,6 @@ void setup(){
     char headerline[500];
     headerline[0] = (char)0;
 
-
-    Serial.println("Setting up BLE.");
-    // ble.begin("BleSerialTest");
-
     Serial.println("Initialising i2c");
     setup_i2c(SDA, SCL);
     
@@ -70,7 +66,6 @@ void setup(){
     // sprintf(headerline, "%d", unix_timestamp);
     strcat(headerline, unix_timestamp);
     setup_sdcard(unix_timestamp);
-    
     
     write_values(headerline);
     digitalWrite(LED_BLUE, LOW);

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -42,12 +42,9 @@ void setup(){
     char headerline[500];
     headerline[0] = (char)0;
 
-    // ------SETUP SD------------
-    gen_timestamp(unix_timestamp);
-    Serial.println(unix_timestamp);
-    // sprintf(headerline, "%d", unix_timestamp);
-    strcat(headerline, unix_timestamp);
-    setup_sdcard(unix_timestamp);
+
+    Serial.println("Setting up BLE.");
+    // ble.begin("BleSerialTest");
 
     Serial.println("Initialising i2c");
     setup_i2c(SDA, SCL);
@@ -62,8 +59,15 @@ void setup(){
         sprintf(unit_buffer, ":g%dx;g%dy;g%dz;a%dy;a%dp;a%dr", i,i,i,i,i,i);
         strcat(headerline, unit_buffer);
     } 
-
-
+    
+    // ------SETUP SD------------
+    gen_timestamp(unix_timestamp);
+    Serial.println(unix_timestamp);
+    // sprintf(headerline, "%d", unix_timestamp);
+    strcat(headerline, unix_timestamp);
+    setup_sdcard(unix_timestamp);
+    
+    
     write_values(headerline);
     digitalWrite(LED_BLUE, LOW);
     digitalWrite(LED_GREEN, HIGH);

--- a/Hardware/Firmware/mainboard/src/timestamp.cpp
+++ b/Hardware/Firmware/mainboard/src/timestamp.cpp
@@ -33,7 +33,8 @@ String time_now;
 void initWiFi() {
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
-  Serial.print("Connecting to WiFi ..");
+  Serial.print("Connecting to WiFi: ");
+  Serial.println(ssid);
   while (WiFi.status() != WL_CONNECTED) {
     Serial.print('.');
     delay(1000);


### PR DESCRIPTION
While we won't stream Serial data over Bluetooth, some of the changes made on this branch are still relevant.
These mainly include the addition of 16MB flash size support and the SD setup after the sensor setup.

The minor ones are:
- Printing the name of the WIFI network it's trying to connect to
- commented out lines that cause infinite loop when sensor fails