### PR TITLE
19 PIO environments for different hands

### DIFF
--- a/Hardware/Firmware/mainboard/include/config.h
+++ b/Hardware/Firmware/mainboard/include/config.h
@@ -37,11 +37,27 @@ struct offsets {
     int xa, ya, za, xg, yg, zg;
 };
 
-const offsets mpu_offsets[] = {
-    {-262, -2994, 1711, -174, 214, 46},
-    {-6018, 1394, 1385, 66, -86, 35},
-    {-3296, 434, 1879, 377, -178, -6},
-    {-889, -4586, 1050, 117, -242, 54},
-    {2071, -3990, 1582, -42, 119, 58},
-    {-2539, -2304, 372, 90, 3, 18},
-};
+#ifndef RIGHT_HAND
+#error Specify hand.
+#endif
+
+#if RIGHT_HAND
+    const offsets mpu_offsets[] = {
+        {-262, -2994, 1711, -174, 214, 46}, // Thumb
+        {-6018, 1394, 1385, 66, -86, 35}, // Index
+        {-3296, 434, 1879, 377, -178, -6}, // Middle
+        {-889, -4586, 1050, 117, -242, 54}, // Ring 
+        {2071, -3990, 1582, -42, 119, 58}, // Pinky
+        {-2539, -2304, 372, 90, 3, 18}, // Onboard
+    };
+#else
+    // Remember: this config is also in reverse order if sensors_array is switched
+    const offsets mpu_offsets[] = {
+        {2071, -3990, 1582, -42, 119, 58}, // Thumb
+        {-889, -4586, 1050, 117, -242, 54}, // Index
+        {-3296, 434, 1879, 377, -178, -6}, // Middle
+        {-6018, 1394, 1385, 66, -86, 35}, // Ring
+        {-262, -2994, 1711, -174, 214, 46}, // Pinky
+        {-2539, -2304, 372, 90, 3, 18}, // Onboard
+    };
+#endif

--- a/Hardware/Firmware/mainboard/include/sensors.h
+++ b/Hardware/Firmware/mainboard/include/sensors.h
@@ -1,5 +1,6 @@
 void setup_i2c(int sda, int scl);
 int setup_sensor(int id);
+void setup_sensors();
 // reading sense_readings(MPU6050 mpu);
 void get_all_readings(reading* output);
 void format_readings(reading* input, char* output_buf);

--- a/Hardware/Firmware/mainboard/platformio.ini
+++ b/Hardware/Firmware/mainboard/platformio.ini
@@ -10,8 +10,9 @@
 
 [platformio]
 extra_configs = wifi.ini
+default_envs = left
 
-[env:esp32dev]
+[env]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -22,3 +23,13 @@ lib_deps = ropg/ezTime
 monitor_speed = 115200
 build_flags = 
     ${wifi.wifi_flags}
+
+[env:left]
+build_flags =
+    ${wifi.wifi_flags}
+    -D RIGHT_HAND=0
+
+[env:right]
+build_flags =
+    ${wifi.wifi_flags}
+    -D RIGHT_HAND=1

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -54,15 +54,8 @@ void setup(){
 
     // ------SETUP SENSORS-------
     Serial.println("Setting up Sensors");
-    char unit_buffer[30];
-    for (int i=0;i<SENSOR_COUNT;i++) {
-        if (setup_sensor(i)) {
-            Serial.println("--------WARNING: A SENSOR FAILED-------");
-        }
-        sprintf(unit_buffer, ":g%dx;g%dy;g%dz;a%dy;a%dp;a%dr", i,i,i,i,i,i);
-        strcat(headerline, unit_buffer);
-    } 
 
+    setup_sensors();
 
     write_values(headerline);
     digitalWrite(LED_BLUE, LOW);

--- a/Hardware/Firmware/mainboard/src/sensors.cpp
+++ b/Hardware/Firmware/mainboard/src/sensors.cpp
@@ -144,7 +144,7 @@ void setup_sensors() {
         if (setup_sensor(i)) {
             Serial.println("--------WARNING: A SENSOR FAILED-------");
         }
-   } 
+   }
 }
 
 void reset_all_bufs() {

--- a/Hardware/Firmware/mainboard/src/sensors.cpp
+++ b/Hardware/Firmware/mainboard/src/sensors.cpp
@@ -218,15 +218,22 @@ reading sense_readings(MPU6050 mpu) {
     // float yaw = ypr[0]* 180/M_PI;
     // float pitch = ypr[1]* 180/M_PI;
     // float roll = ypr[2]* 180/M_PI;
-    output.ax = aaReal.x;
-    output.ay = aaReal.y;
-    output.az = aaReal.z;
     // output.gx = ypr[0]* 180/M_PI;
     // output.gy = ypr[1]* 180/M_PI;
     // output.gz = ypr[2]* 180/M_PI;
+    if (RIGHT_HAND == 1) {
+        output.ax = aaReal.x * -1;
+        output.ay = aaReal.y * -1;
+        output.gy = ypr[1] * -1;
+        output.gz = ypr[2] * -1;
+    } else {
+        output.ax = aaReal.x;
+        output.ay = aaReal.y;
+        output.gy = ypr[1];
+        output.gz = ypr[2];
+    }
     output.gx = ypr[0];
-    output.gy = ypr[1];
-    output.gz = ypr[2];
+    output.az = aaReal.z;
 
     // Serial.println("Returning values...");
     return output;


### PR DESCRIPTION
Added environments `left` and `right` in *platformio.ini*.
Can be chosen by adding `-e [left/right]` when compiling. Standard environment is `left`.

For the right hand the firmware adjusts the multiplexer channels, so the sensors are still in the order of the fingers:
*[Thumb, Index, Middle, Ring, Pinky]*

Additionally, the following values are negated:
- x & y acceleration
- y & z rotation

to mirror the left hand.

