### PR TITLE
Added build flag MULT_CORE

### DIFF
--- a/Hardware/Firmware/mainboard/include/config.h
+++ b/Hardware/Firmware/mainboard/include/config.h
@@ -41,6 +41,11 @@ struct offsets {
 #error Specify hand.
 #endif
 
+#ifndef MULT_CORE
+#define MULT_CORE 1
+#endif 
+
+
 #if RIGHT_HAND
     const offsets mpu_offsets[] = {
         {-262, -2994, 1711, -174, 214, 46}, // Thumb

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -62,7 +62,10 @@ void setup(){
     digitalWrite(LED_GREEN, HIGH);
     
     // ------Parallelization setup------
-    xTaskCreatePinnedToCore(task_fifo_reset, "fifo_resets", 10000, NULL, 1, &TaskFifoReset, 0);
+    if (MULT_CORE){
+        xTaskCreatePinnedToCore(task_fifo_reset, "fifo_resets", 10000, NULL, 1, &TaskFifoReset, 0);
+        Serial.println("Parallelization enabled.");
+    }
     
     timer_battery_check.start();
   

--- a/Hardware/Firmware/mainboard/src/sensors.cpp
+++ b/Hardware/Firmware/mainboard/src/sensors.cpp
@@ -178,9 +178,11 @@ void readFifoBuffer(MPU6050 mpu) {
 
     __TIMING("after reset: %d \n");
 
-    uxBits = xEventGroupGetBits(FifoResetEventGroup);
-    while((uxBits & BIT_0) != 0){
+    if (MULT_CORE){
         uxBits = xEventGroupGetBits(FifoResetEventGroup);
+        while((uxBits & BIT_0) != 0){
+            uxBits = xEventGroupGetBits(FifoResetEventGroup);
+        }
     }
 
     __TIMING("Before get: %d \n");
@@ -250,7 +252,11 @@ void get_all_readings(reading* output) {
             // Serial.println("Got some values");
         }     
     }
-    xEventGroupSetBits(FifoResetEventGroup, BIT_0);
+    if (!MULT_CORE){
+        reset_all_bufs();
+    } else {
+        xEventGroupSetBits(FifoResetEventGroup, BIT_0);
+    }
 }
 
 void format_readings(reading* input, char* output_buf) {


### PR DESCRIPTION
MULT_CORE is set to 1 by default (if not defined), enabling parallelization. MULT_CORE=0 disables it.

By setting the environment variable `PLATFORMIO_BUILD_FLAGS`  additional build flags can be passed at `pio run` level. ([source](https://community.platformio.org/t/pass-global-define-at-run-time/1439/9)).

So the command to flash the firmware with parallelization looks like this:
`PLATFORMIO_BUILD_FLAGS=-DMULT_CORE=0 pio run -t upload`
