### PR TITLE
Build flag BLE_SERIAL fully functional

### DIFF
--- a/Hardware/Firmware/mainboard/platformio.ini
+++ b/Hardware/Firmware/mainboard/platformio.ini
@@ -23,6 +23,8 @@ lib_deps = ropg/ezTime
     jrowberg/I2Cdevlib-MPU6050
     sstaub/TickTwo
     eeprom
+    avinabmalla/ESP32_BleSerial
+
 monitor_speed = 115200
 build_flags = 
     ${wifi.wifi_flags}

--- a/Hardware/Firmware/mainboard/src/main.cpp
+++ b/Hardware/Firmware/mainboard/src/main.cpp
@@ -10,17 +10,17 @@
 #include "sensors.h"
 
 
-// #if BLE_SERIAL
-//
-// #include <BLEDevice.h>
-// #include <BleSerial.h>
-// BleSerial ble;
-//
-// #endif
+#if BLE_SERIAL
 
 #include <BLEDevice.h>
 #include <BleSerial.h>
 BleSerial ble;
+
+#endif
+
+// #include <BLEDevice.h>
+// #include <BleSerial.h>
+// BleSerial ble;
 
 // ------ TICKERS ------
 #include <TickTwo.h>
@@ -82,13 +82,16 @@ void setup(){
     
     timer_battery_check.start();
 
-    if (BLE_SERIAL){
-// #if BLE_SERIAL
-        ble.begin("Lapcal left");
-        ble.println("Hello World!");
-        Serial.println("BLESerial started.");
-// #endif
+#if BLE_SERIAL
+    
+    if (RIGHT_HAND){
+        ble.begin("Lapcal right", true, 13);
+    } else {
+        ble.begin("Lapcal left", true, 13);
     }
+    ble.println(unix_timestamp);
+    Serial.println("BLESerial started.");
+#endif
 
     // ---- TIME SINGLE CYCLE ----
     //
@@ -107,20 +110,12 @@ void loop(){
     format_readings(all_readings, all_readings_charbuf);
 
 
-    if (BLE_SERIAL){
+#if BLE_SERIAL
         ble.println(all_readings_charbuf);
-    }
-    else {
+#else
         write_values(all_readings_charbuf);
-    }
+#endif
    
-// #if BLE_SERIAL
-//     ble.println(all_readings_charbuf);
-// #else
-//     write_values(all_readings_charbuf);
-// #endif
-
-
     // Serial.println("Checking bat_stat");
     if (check_bat_flag){
     // Serial.println("Checking bat...");


### PR DESCRIPTION
Build flag is now functional and if not set, the library is not included.

The library is now also added via platformio.ini instead of locally.

The `ble.begin()` call includes the options that enable the builtin led (pin 13), and name the device "lapcal [left/right]" depending on the hand set.

Closes #44.

To set build_flags: prepend `PLATFORMIO_BUILD_FLAGS="-DMULT_CORE=[0/1] -DBLE_SERIAL=[0/1] -DRIGHT_HAND=[0/1]"` for example to `pio run` commands.